### PR TITLE
Unary minus refactor

### DIFF
--- a/checkr/src/interpreter.rs
+++ b/checkr/src/interpreter.rs
@@ -151,9 +151,7 @@ impl AExpr {
                 }
             }
             AExpr::Binary(l, op, r) => op.semantic(l.semantics(m)?, r.semantics(m)?)?,
-            AExpr::Minus(n) => {
-                (n.semantics(m)?).checked_neg().ok_or(InterpreterError::ArithmeticOverflow)?
-            }
+            AExpr::Minus(n) => (n.semantics(m)?).checked_neg().ok_or(InterpreterError::ArithmeticOverflow)?,
             AExpr::Function(f) => return Err(todo!("evaluating functions {f}")),
         })
     }

--- a/checkr/src/interpreter.rs
+++ b/checkr/src/interpreter.rs
@@ -151,7 +151,9 @@ impl AExpr {
                 }
             }
             AExpr::Binary(l, op, r) => op.semantic(l.semantics(m)?, r.semantics(m)?)?,
-            AExpr::Minus(n) => (n.semantics(m)?).checked_neg().ok_or(InterpreterError::ArithmeticOverflow)?,
+            AExpr::Minus(n) => (n.semantics(m)?)
+                .checked_neg()
+                .ok_or(InterpreterError::ArithmeticOverflow)?,
             AExpr::Function(f) => return Err(todo!("evaluating functions {f}")),
         })
     }


### PR DESCRIPTION
This refactors the unary minus overflow bug fix from previously, and this should hopefully also meet `cargo fmt` formatting standards