### PR TITLE
IO and `programs.toml` refactor

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2317,6 +2317,7 @@ dependencies = [
  "notify",
  "notify-debouncer-mini",
  "open",
+ "rand",
  "serde",
  "serde_json",
  "tokio",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -16,6 +16,7 @@ comfy-table = { version = "6.1.4", default-features = false }
 itertools = "0.10.5"
 serde = { version = "1.0.152", features = ["derive"] }
 serde_json = "1.0.91"
+rand = { version = "0.8.5", features = ["small_rng"] }
 thiserror = "1.0.38"
 tokio = { version = "1.25.0", features = ["full"] }
 tracing = "0.1.37"

--- a/checko/example/programs.toml
+++ b/checko/example/programs.toml
@@ -1,9 +1,18 @@
-[[programs]]
+[[envs.Graph]]
 seed = 125234
 shown = true
 
-[[programs]]
+[[envs.Graph]]
 seed = 12353
 src = '''
 x := y ; y := -x
+'''
+
+[[envs.Interpreter]]
+seed = 12353
+src = '''
+x := y ; y := -x
+'''
+input = '''
+    {"assignment":{"arrays":{},"variables":{"x":-1,"y":-8}},"determinism":{"Case":"Deterministic"},"trace_length":11}
 '''

--- a/checko/src/config.rs
+++ b/checko/src/config.rs
@@ -1,26 +1,105 @@
 //! Config definitions for program inputs and groups of group.
 
+use checkr::{env::Analysis, GeneratedProgram};
+use color_eyre::Result;
+use indexmap::IndexMap;
 use serde::{Deserialize, Serialize};
 
-#[derive(Debug, Clone, Serialize, Deserialize)]
+#[derive(Debug, Default, Clone, Serialize, Deserialize)]
 pub struct GroupsConfig {
     pub groups: Vec<GroupConfig>,
 }
 
-#[derive(Debug, Clone, Serialize, Deserialize)]
+#[derive(Debug, Default, Clone, Serialize, Deserialize)]
 pub struct ProgramsConfig {
+    pub envs: IndexMap<Analysis, ProgramsEnvConfig>,
+}
+
+#[derive(Debug, Default, Clone, Serialize, Deserialize)]
+#[serde(transparent)]
+pub struct ProgramsEnvConfig {
     pub programs: Vec<ProgramConfig>,
 }
 
 #[derive(Debug, Clone, Serialize, Deserialize)]
 pub struct ProgramConfig {
-    pub seed: u64,
+    pub seed: Option<u64>,
     pub src: Option<String>,
+    pub input: Option<String>,
     #[serde(default)]
     pub shown: bool,
 }
 
+#[derive(Debug, Default, Clone, Serialize, Deserialize)]
+pub struct CanonicalProgramsConfig {
+    pub envs: IndexMap<Analysis, CanonicalProgramsEnvConfig>,
+}
+#[derive(Debug, Default, Clone, Serialize, Deserialize)]
+#[serde(transparent)]
+pub struct CanonicalProgramsEnvConfig {
+    pub programs: Vec<CanonicalProgramConfig>,
+}
 #[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct CanonicalProgramConfig {
+    pub src: String,
+    pub input: String,
+    pub shown: bool,
+}
+impl ProgramsConfig {
+    pub fn extend(&mut self, other: Self) {
+        for (analysis, env) in other.envs {
+            self.envs
+                .entry(analysis)
+                .or_default()
+                .programs
+                .extend_from_slice(&env.programs);
+        }
+    }
+}
+impl ProgramConfig {
+    pub fn generated_program(&self, analysis: Analysis) -> Result<GeneratedProgram> {
+        Ok(match self {
+            ProgramConfig {
+                seed: Some(seed),
+                src: None,
+                input: None,
+                ..
+            } => analysis.setup_generation().seed(Some(*seed)).build(),
+            ProgramConfig {
+                seed: Some(seed),
+                src: Some(src),
+                input: None,
+                ..
+            } => {
+                let builder = analysis.setup_generation().seed(Some(*seed));
+                builder.from_cmds(checkr::parse::parse_commands(src).unwrap())
+            }
+            ProgramConfig {
+                src: Some(src),
+                input: Some(input),
+                ..
+            } => {
+                let builder = analysis.setup_generation();
+                builder.from_cmds_and_input(
+                    checkr::parse::parse_commands(src).unwrap(),
+                    analysis.input_from_str(input)?,
+                )
+            }
+            _ => todo!(),
+        })
+    }
+    pub fn canonicalize(&self, analysis: Analysis) -> Result<CanonicalProgramConfig> {
+        let p = self.generated_program(analysis)?;
+
+        Ok(CanonicalProgramConfig {
+            src: p.cmds.to_string(),
+            input: p.input.to_string(),
+            shown: self.shown,
+        })
+    }
+}
+
+#[derive(Debug, Default, Clone, Serialize, Deserialize)]
 pub struct GroupConfig {
     pub name: String,
     pub git: String,

--- a/checko/src/main.rs
+++ b/checko/src/main.rs
@@ -1,5 +1,3 @@
-#![feature(try_blocks)]
-
 use std::{
     fs,
     path::{Path, PathBuf},
@@ -130,7 +128,8 @@ async fn run() -> Result<()> {
                         info!("evaluating group");
                         let env = GroupEnv::new(&submissions, &g);
 
-                        let result: Result<()> = try {
+                        // TODO: Replace this with a try-block when they are stable
+                        let result: Result<()> = (|| async {
                             let (sh, _) = env
                                 .shell_in_default_branch()
                                 .wrap_err("getting shell in default branch")?;
@@ -143,7 +142,9 @@ async fn run() -> Result<()> {
                                 "writing result"
                             );
                             env.write_latest_run(&output)?;
-                        };
+                            Ok(())
+                        })()
+                        .await;
 
                         if let Err(e) = result {
                             error!(error = e.to_string(), "errored");

--- a/checkr/Cargo.toml
+++ b/checkr/Cargo.toml
@@ -21,7 +21,7 @@ lalrpop-util = { version = "0.19.8", features = ["lexer"] }
 miette = { version = "5.5.0", features = ["fancy"] }
 once_cell = "1.17.0"
 petgraph = { version = "0.6.3" }
-rand = { version = "0.8.5", features = ["small_rng"] }
+rand = { workspace = true }
 serde = { workspace = true }
 serde_json = { workspace = true }
 thiserror = { workspace = true }

--- a/checkr/src/env/pv.rs
+++ b/checkr/src/env/pv.rs
@@ -102,7 +102,7 @@ impl Environment for ProgramVerificationEnv {
     fn setup_generation(&self) -> crate::ProgramGenerationBuilder {
         crate::ast::Command::reset_sp_counter();
 
-        crate::ProgramGenerationBuilder::default()
+        crate::ProgramGenerationBuilder::new(Self::ANALYSIS)
             .no_loop(true)
             .no_division(true)
             .generate_annotated(true)

--- a/checkr/src/main.rs
+++ b/checkr/src/main.rs
@@ -29,7 +29,7 @@ fn main() -> color_eyre::Result<()> {
             input,
         } => {
             let cmds = parse::parse_commands(&src)?;
-            let output = analysis.run(&cmds, &input)?;
+            let output = analysis.run(&cmds, analysis.input_from_str(&input)?)?;
 
             println!("{output}");
 

--- a/inspectify/Cargo.toml
+++ b/inspectify/Cargo.toml
@@ -14,6 +14,7 @@ axum-macros = "0.3.1"
 binswap-github = "0.1.6"
 checko = { workspace = true }
 checkr = { workspace = true }
+rand = { workspace = true }
 clap = { version = "4.1.1", features = ["derive"] }
 color-eyre = { workspace = true }
 crossterm = "0.26.0"

--- a/xtask/Cargo.toml
+++ b/xtask/Cargo.toml
@@ -15,5 +15,5 @@ binswap-github = "0.1.6"
 clap = { version = "4.1.4", features = ["derive"] }
 color-eyre = { workspace = true }
 tokio = { workspace = true }
-toml_edit = "0.19.3"
+toml_edit = "0.19.8"
 xshell = "0.2.3"


### PR DESCRIPTION
- Remove `#![feature(try_blocks)]` which now allows us to compile on stable!
- Instead of passing input/output strings around, we wrap them in `Input`/`Output` structs which contains `serde_json::Value`. This will probably allow better error messages, with distinguishing invalid JSON vs invalid structure.
- One can now pass multiple `--programs` which are joined together.
- `programs.toml` now requires each program to be assigned to a single analysis env. This then also allows for explicit inputs!