### PR TITLE
Dir path bug

### DIFF
--- a/checkr/src/driver.rs
+++ b/checkr/src/driver.rs
@@ -78,11 +78,12 @@ impl Driver {
             compile_output: Some(compile_output),
         })
     }
-    
-    //Generates a string with initial dots removed, and any initial path specifier, as well as doing the same from the back
+
+    //Generates a string with initial dot removed (if it contains this), and any initial path / or \, as well as doing the same from the back
     fn clear_format(st: String) -> String {
-        let mut process: std::collections::VecDeque<char> = std::collections::VecDeque::from(st.chars().collect::<Vec<char>>());
-        
+        let mut process: std::collections::VecDeque<char> =
+            std::collections::VecDeque::from(st.chars().collect::<Vec<char>>());
+
         //Remove initial dot if it exists and there is only 1 of them
         if !process.is_empty() && *process.front().unwrap() == '.' {
             process.pop_front();
@@ -90,39 +91,42 @@ impl Driver {
                 process.push_front('.');
             }
         }
-        
+
         //Remove / and \ from the front
-        while !process.is_empty() && (*process.front().unwrap() == '/' || *process.front().unwrap() == '\\') {
+        while !process.is_empty()
+            && (*process.front().unwrap() == '/' || *process.front().unwrap() == '\\')
+        {
             process.pop_front();
         }
-        
+
         //Remove / and \ from the back
-        while !process.is_empty() && (*process.back().unwrap() == '/' || *process.back().unwrap() == '\\') {
+        while !process.is_empty()
+            && (*process.back().unwrap() == '/' || *process.back().unwrap() == '\\')
+        {
             process.pop_back();
         }
-        
+
         let mut result: String = String::new();
-        
+
         while !process.is_empty() {
             result.push(*process.front().unwrap());
             process.pop_front();
         }
-        
+
         result
-        
     }
-    
+
     //Formats the cmd argument to have the directory pre-pended to it.
     fn format_cmd(cmd: String, dir: String) -> String {
         let format_cmd = Driver::clear_format(cmd);
         let format_dir = Driver::clear_format(dir);
         let mut result: String = String::from(""); //new cmd with directory path pre-pended to it.
-        
+
         //Checks if the path is not absolute (Single Drive letter + : on Windows)
         if !(format_dir.len() >= 2 && &format_dir[1..2] == ":") {
             result.push_str("./");
         }
-        
+
         if format_dir.len() != 0 {
             result.push_str(&format_dir);
             result.push_str("/");
@@ -130,14 +134,11 @@ impl Driver {
         result.push_str(&format_cmd);
         result
     }
-    
+
     fn new_command(&self) -> Command {
-        let new_cmd: String = Driver::format_cmd(self.run_cmd.clone(), self.dir.to_str().unwrap().to_string()); //new cmd with directory path pre-pended to it.
-        
-        eprintln!("CMD DATA: {}", &self.run_cmd);
-        eprintln!("CMD Dir: {}", self.dir.to_str().unwrap());
-        eprintln!("CMD NEW: {}", &new_cmd);
-        
+        let new_cmd: String =
+            Driver::format_cmd(self.run_cmd.clone(), self.dir.to_str().unwrap().to_string()); //new cmd with directory path pre-pended to it.
+
         let mut args = new_cmd.split(' ');
         let mut cmd = Command::new(args.next().unwrap());
         cmd.args(args);

--- a/checkr/src/driver.rs
+++ b/checkr/src/driver.rs
@@ -136,8 +136,12 @@ impl Driver {
     }
 
     fn new_command(&self) -> Command {
-        let new_cmd: String =
-            Driver::format_cmd(self.run_cmd.clone(), self.dir.to_str().unwrap().to_string()); //new cmd with directory path pre-pended to it.
+        let new_cmd: String = match std::env::consts::OS {
+            "windows" => {
+                Driver::format_cmd(self.run_cmd.clone(), self.dir.to_str().unwrap().to_string())
+            } //new cmd with directory path pre-pended to it.
+            _ => self.run_cmd.clone(),
+        };
 
         let mut args = new_cmd.split(' ');
         let mut cmd = Command::new(args.next().unwrap());

--- a/checkr/src/driver.rs
+++ b/checkr/src/driver.rs
@@ -78,9 +78,67 @@ impl Driver {
             compile_output: Some(compile_output),
         })
     }
+    
+    //Generates a string with initial dots removed, and any initial path specifier, as well as doing the same from the back
+    fn clear_format(st: String) -> String {
+        let mut process: std::collections::VecDeque<char> = std::collections::VecDeque::from(st.chars().collect::<Vec<char>>());
+        
+        //Remove initial dot if it exists and there is only 1 of them
+        if !process.is_empty() && *process.front().unwrap() == '.' {
+            process.pop_front();
+            if !process.is_empty() && *process.front().unwrap() == '.' {
+                process.push_front('.');
+            }
+        }
+        
+        //Remove / and \ from the front
+        while !process.is_empty() && (*process.front().unwrap() == '/' || *process.front().unwrap() == '\\') {
+            process.pop_front();
+        }
+        
+        //Remove / and \ from the back
+        while !process.is_empty() && (*process.back().unwrap() == '/' || *process.back().unwrap() == '\\') {
+            process.pop_back();
+        }
+        
+        let mut result: String = String::new();
+        
+        while !process.is_empty() {
+            result.push(*process.front().unwrap());
+            process.pop_front();
+        }
+        
+        result
+        
+    }
+    
+    //Formats the cmd argument to have the directory pre-pended to it.
+    fn format_cmd(cmd: String, dir: String) -> String {
+        let format_cmd = Driver::clear_format(cmd);
+        let format_dir = Driver::clear_format(dir);
+        let mut result: String = String::from(""); //new cmd with directory path pre-pended to it.
+        
+        //Checks if the path is not absolute (Single Drive letter + : on Windows)
+        if !(format_dir.len() >= 2 && &format_dir[1..2] == ":") {
+            result.push_str("./");
+        }
+        
+        if format_dir.len() != 0 {
+            result.push_str(&format_dir);
+            result.push_str("/");
+        }
+        result.push_str(&format_cmd);
+        result
+    }
+    
     fn new_command(&self) -> Command {
-        let mut args = self.run_cmd.split(' ');
-
+        let new_cmd: String = Driver::format_cmd(self.run_cmd.clone(), self.dir.to_str().unwrap().to_string()); //new cmd with directory path pre-pended to it.
+        
+        eprintln!("CMD DATA: {}", &self.run_cmd);
+        eprintln!("CMD Dir: {}", self.dir.to_str().unwrap());
+        eprintln!("CMD NEW: {}", &new_cmd);
+        
+        let mut args = new_cmd.split(' ');
         let mut cmd = Command::new(args.next().unwrap());
         cmd.args(args);
         cmd.current_dir(&self.dir);


### PR DESCRIPTION
Alternative fix to the dir path bug problem. This seemingly fixes the issue on Windows 10, though I have not tested the modifications on Linux / OS X or other Windows versions.

In essence, what these changes should do, is that in the `new_command` function of the driver, it performs a check to see, whether the OS is `windows`. If this is the case, it applies a custom formatting command (`format_cmd`), otherwise, it should proceed as before.

New commands:
`clear_format`: When parsed a string, it removes the singular `.` from the front if it is there, otherwise, if it is `..` or more dots, it should not remove these. Then, after this, it will attempt to remove all consecutive `/` and `\` reachable from the front and the back, which purpose is to eventually yield a string with some format where the leftmost part of the string is a folder name, and the rightmost part is also a folder name.

`format_cmd`: This cleans both the program's cmd path and user specified dir path with `clear_format`, then, if dir is a non-zero string, appends cmd path to the dir path, making sure to place a `/` between the two, which should be doable, since neither end or begin with a `/` or `\`. Likewise, it checks the dir path for a drive letter format, if not, then it appends `./` as would otherwise be there.

Hopefully this solves the problem, or at the very least, lets us move towards a more complete solution 🙂 
